### PR TITLE
Remove /etc/resolv.conf before configure dns servers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,16 @@
     - dns
     - dns-remove-resolvconf
 
+- name: remove resolvconf symlink
+  file:
+    path: /etc/resolv.conf
+    state: absent
+  when: dns_remove_resolvconf
+  tags:
+    - configuration
+    - dns
+    - dns-remove-resolvconf
+
 - name: configure dns servers - /etc/resolv.conf
   template:
     src: etc/resolv.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,15 @@
     - dns
     - dns-remove-resolvconf
 
+- stat:
+    path: /etc/resolv.conf
+  register: stat_resolvconf
+
 - name: remove resolvconf symlink
   file:
     path: /etc/resolv.conf
     state: absent
-  when: dns_remove_resolvconf
+  when: dns_remove_resolvconf and stat_resolvconf.stat.islnk is defined and stat_resolvconf.stat.islnk
   tags:
     - configuration
     - dns


### PR DESCRIPTION
Removing `resolvconf` package without reboot,  keeps `/etc/resolv.conf` symlink to `/run/resolvconf/resolv.conf`.

Task `configure dns servers - /etc/resolv.conf` copy template to `dest: /etc/resolv.conf` wich is symlink.
After reboot system will fail.